### PR TITLE
support players with null "first name"

### DIFF
--- a/app/controllers/admin/players_controller.rb
+++ b/app/controllers/admin/players_controller.rb
@@ -70,14 +70,15 @@ module Admin
     def update_from_id(params)
       hash = ActiveSupport::HashWithIndifferentAccess.new
       keys = [:first_name, :last_name, :fed, :title, :gender]
+      allow_null = [:first_name, :last_name]
       if params[:icu_id] && ip = IcuPlayer.find_by_id(params[:icu_id])
         hash[:icu_id] = params[:icu_id]
-        keys.each { |k| v = ip.send(k); hash[k] = v if v.present? }
+        keys.each { |k| v = ip.send(k); hash[k] = v if (v.present? || allow_null.include?(k)) }
         hash[:dob] = ip.dob if ip.dob.present?
         hash[:fide_id] = ip.fide_player.id if ip.fide_player
       elsif params[:fide_id] && fp = FidePlayer.find_by_id(params[:fide_id])
         hash[:fide_id] = params[:fide_id]
-        keys.each { |k| v = fp.send(k); hash[k] = v if v.present? }
+        keys.each { |k| v = fp.send(k); hash[k] = v if (v.present? || allow_null.include?(k))}
         hash[:fide_rating] = fp.rating unless @player.fide_rating
       end
       params[:player] = hash

--- a/app/models/player.rb
+++ b/app/models/player.rb
@@ -70,7 +70,7 @@ class Player < ActiveRecord::Base
 
   before_validation :normalise_attributes, :canonicalize_names, :deduce_category_and_status
 
-  validates :first_name, :last_name, :original_name, :status, presence: true
+  validates :last_name, :original_name, :status, presence: true
   validates :icu_id, :original_icu_id, numericality: { only_integer: true, greater_than: 0 }, allow_nil: true
   validates :fide_id, :original_fide_id, numericality: { only_integer: true, greater_than: 0 }, allow_nil: true
   validates :fed, :original_fed, inclusion: { in: FEDS, message: "(%{value}) is invalid" }, allow_nil: true


### PR DESCRIPTION
Removed the requirement for first_name to be non-null, and allowed
the FIDE ID-picker to update a name parameter to be null.

This needs to be supported as some players have no first name in
the FIDE database. E.g. Sarthak Bathla.

There is also an icu_name change that goes along with this.